### PR TITLE
Reproduire la photo en HTML

### DIFF
--- a/releve.html
+++ b/releve.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="fr">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Relevé — reproduction exacte</title>
+	<style>
+		:root { --page-width: 210mm; }
+		html, body { height: 100%; margin: 0; background: #e6e6e6; }
+		.page {
+			width: var(--page-width);
+			margin: 16px auto;
+			background: #fff;
+			box-shadow: 0 0 0 1px rgba(0,0,0,.08), 0 12px 28px rgba(0,0,0,.18);
+		}
+		.page img { width: 100%; height: auto; display: block; }
+		@media (max-width: 840px) {
+			.page { width: 100vw; margin: 0; box-shadow: none; }
+		}
+		@page { size: A4 portrait; margin: 0; }
+		@media print {
+			html, body { background: transparent; }
+			.page { width: 210mm; margin: 0; box-shadow: none; }
+		}
+	</style>
+</head>
+<body>
+	<main class="page" aria-label="Reproduction exacte du document">
+		<img src="releve.jpg" alt="Relevé de cotes — ISC Goma" />
+	</main>
+</body>
+</html>


### PR DESCRIPTION
Add `releve.html` to display `releve.jpg` exactly, sized to an A4 page with zero print margins.

---
<a href="https://cursor.com/background-agent?bcId=bc-c479d79f-ac48-4578-b193-c646e0bfe313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c479d79f-ac48-4578-b193-c646e0bfe313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

